### PR TITLE
vf128: normalized value compression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,11 @@ add_library(vf8 STATIC src/vf128.cc)
 add_executable(bench_io test/bench_io.cc)
 target_link_libraries(bench_io vf8)
 
+add_executable(rand_io test/rand_io.cc)
+target_link_libraries(rand_io vf8)
+
 enable_testing()
 
-foreach(prog IN ITEMS t1)
-	add_executable(${prog} test/${prog}.c)
-	target_link_libraries(${prog} vf8)
-	add_test(test_${prog} ${prog})
-endforeach()
+add_executable(t1 test/t1.c)
+target_link_libraries(t1 vf8)
+add_test(test_t1 t1)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The _vf128_ variable length floating-point format provides:
 
 - compact variable length storage of IEEE 754 floating-point values.
 - mantissa encoding that supports quantization on 8-bit boundaries.
-- succinct integer encoding with only a mantissa omitting the exponent.
-- succinct power-of-two encoding with only an exponent omitting the mantissa.
+- succinct normalized values with unary exponent (-0.99999.. to 0.99999..).
+- succinct power-of-two encoding with implicit mantissa.
 - small floating point values inlined within the header:
   - -0.5 to 0.5 step 0.0625, -3.875 to 3.875 step 0.125,
     ±Zero, ±Inf, and ±NaN.
@@ -141,10 +141,11 @@ to the explicit leading one. To decode, one simply detects values which have
 an exponent less than the minimum exponent of the type that is being decoded
 into, and shift the fraction accordingly.
 
-### integers
+### normalized values with unary exponent
 
-Integers are encoded with zero in the exponent field, and the integer length
-in the mantissa field. The integer bytes follow the header.
+Normal values in the range -0.99999.. to +0.99999.. with a binary exponent
+from e-1 to e-8 inclusive are encoded with zero in the exponent field, and the
+exponent is encoded as a unary prefix of trailing zeros in the mantissa field.
 
 - `inline = 0`
 - `exponent = 0`
@@ -152,8 +153,11 @@ in the mantissa field. The integer bytes follow the header.
 - `<mantissa-payload>`
 
 To decode, the leading zeros are counted to find a shift to left-justify
-the integer, truncate the explicit leading one and set the exponent based
-on the number of bits right of the leading one.
+the fraction, and trailing zeros are counted to find the exponent. The
+exponent is encoded as the negated trailing zeros count minus one.
+
+- most float32 values between -0.99999.. to 0.99999 fit in 4 bytes or less
+- most float64 values between -0.99999.. to 0.99999 fit in 8 bytes or less
 
 ### powers-of-two
 

--- a/test/rand_io.cc
+++ b/test/rand_io.cc
@@ -1,0 +1,91 @@
+#undef NDEBUG
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <math.h>
+#include <random>
+
+#include "vf128.h"
+
+void print_header()
+{
+    printf("%4s %5s %8s - %-8s %8s %8s %8s\n",
+        "A", "B", "x", "y", "size(A)", "size(B)", "p");
+}
+
+size_t test_vf64(double f)
+{
+    double r;
+    size_t s;
+    vf_buf *buf = vf_buf_new(128);
+    assert(!vf_f64_write(buf, &f));
+    s = vf_buf_offset(buf);
+    vf_buf_reset(buf);
+    vf_f64_read(buf, &r);
+    assert(isnan(f) ? isnan(r) : f == r);
+    vf_buf_destroy(buf);
+    return s;
+}
+
+void test_vf64_rand(double x, double y, size_t count)
+{
+    size_t s = 0;
+    std::default_random_engine generator;
+    std::uniform_real_distribution<double> distribution(x,y);
+    generator.seed(0);
+    for (size_t i = 0; i < count; i++) {
+        s += test_vf64(distribution(generator));
+    }
+    printf("%4s %5s %8.1g - %-8.1g %8zu %8zu %8.3f %%\n",
+        "f64", "vf128", x, y, count * 8, s, (((double)s / (double)(count * 8)) - 1.)*100.);
+}
+
+size_t test_vf32(float f)
+{
+    float r;
+    size_t s;
+    vf_buf *buf = vf_buf_new(128);
+    assert(!vf_f32_write(buf, &f));
+    s = vf_buf_offset(buf);
+    vf_buf_reset(buf);
+    vf_f32_read(buf, &r);
+    assert(isnan(f) ? isnan(r) : f == r);
+    vf_buf_destroy(buf);
+    return s;
+}
+
+void test_vf32_rand(float x, float y, size_t count)
+{
+    size_t s = 0;
+    std::default_random_engine generator;
+    std::uniform_real_distribution<float> distribution(x,y);
+    generator.seed(0);
+    for (size_t i = 0; i < count; i++) {
+        s += test_vf32(distribution(generator));
+    }
+    printf("%4s %5s %8.1g - %-8.1g %8zu %8zu %8.3f %%\n",
+        "f32", "vf128", x, y, count * 4, s, (((double)s / (double)(count * 4)) - 1.)*100.);
+}
+
+int main(int argc, const char **argv)
+{
+    const size_t count = 1000;
+    print_header();
+    test_vf64_rand(-1,0,count);
+    test_vf64_rand(0,1,count);
+    test_vf64_rand(-0.5,0.5,count);
+    test_vf64_rand(-1,1,count);
+    test_vf64_rand(-10,10,count);
+    test_vf64_rand(-100,100,count);
+    test_vf64_rand(-1000,1000,count);
+    test_vf64_rand(-1e38,1e38,count);
+    test_vf64_rand(-1e307,1e307,count);
+    test_vf32_rand(-1,0,count);
+    test_vf32_rand(0,1,count);
+    test_vf32_rand(-0.5,0.5,count);
+    test_vf32_rand(-1,1,count);
+    test_vf32_rand(-10,10,count);
+    test_vf32_rand(-100,100,count);
+    test_vf32_rand(-1000,1000,count);
+    test_vf32_rand(-1e38,1e38,count);
+}

--- a/test/t1.c
+++ b/test/t1.c
@@ -73,6 +73,7 @@ void test_vf64_loop()
     for (double i = 0.001; i < 0.902; i += 0.050) {
         test_vf64(i);
     }
+    test_vf64(0.000001);
 }
 
 void test_vf32(float f)
@@ -119,6 +120,7 @@ void test_vf32_loop()
     for (float i = 0.001f; i < 0.902f; i += 0.050f) {
         test_vf32(i);
     }
+    test_vf32(0.000001f);
 }
 
 void test_leb(u64 val)


### PR DESCRIPTION
implement an exponent compression scheme for succinct coding of values between -0.99999.. to 0.99999.. excluding +/-0. the new scheme replaces the current integer coding that uses the zero exponent code with a new scheme that prepends exponent as a unary code prefix in the mantissa adding only several bits of information versus an entire extra byte.
    
- many f32 values between -0.99999.. to 0.99999 fit 4 bytes or less
- most f64 values between -0.99999.. to 0.99999 fit 8 bytes or less


Closes #2